### PR TITLE
Added support for IP Unit System

### DIFF
--- a/Psychrometrics_Engine/Compute/DensityHumidityRatio.cs
+++ b/Psychrometrics_Engine/Compute/DensityHumidityRatio.cs
@@ -36,14 +36,23 @@ namespace BH.Engine.Psychrometrics
     public static partial class Compute
     {
         [Description("Calculates density from dry-bulb temperature and humidity ratio.")]
-        [Input("dryBulbTemperature", "dry-bulb temperature (C)")]
-        [Input("humidityRatio", "humidity ratio (kg_water/kg_dryair)")]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("density", "density(kg/m3)")]
-        public static double DensityHumidityRatio(double dryBulbTemperature, double humidityRatio, double pressure)
+        [Input("unitSystem", "SI [IP]")]
+        [Input("dryBulbTemperature", "dry-bulb temperature (C) [(F)]")]
+        [Input("humidityRatio", "humidity ratio (kg_water/kg_dryair) [(lb_water/lb_dryair)]")]
+        [Input("pressure", "pressure (Pa) [(Psi)]")]
+        [Output("density", "density(kg/m3) [lb/ft3)]")]
+        public static double DensityHumidityRatio(string unitSystem, double dryBulbTemperature, double humidityRatio, double pressure )
         {
-            PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
-            return psy.GetMoistAirDensity(dryBulbTemperature, humidityRatio, pressure);
+            if (unitSystem == "SI" || unitSystem == string.Empty)
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
+                            return psy.GetMoistAirDensity(dryBulbTemperature, humidityRatio, pressure);
+            }
+            else
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.IP);
+                return psy.GetMoistAirDensity(dryBulbTemperature, humidityRatio, pressure);
+            }
         }
     }
 }

--- a/Psychrometrics_Engine/Compute/DensityRelativeHumidity.cs
+++ b/Psychrometrics_Engine/Compute/DensityRelativeHumidity.cs
@@ -33,16 +33,30 @@ namespace BH.Engine.Psychrometrics
     public static partial class Compute
     {
         [Description("Calculates density from dry-bulb temperature and relative humidity.")]
-        [Input("dryBulbTemperature", "dry-bulb temperature (C)")]
+        [Input("unitSystem", "SI [IP]")]
+        [Input("dryBulbTemperature", "dry-bulb temperature (C) [(F)]")]
         [Input("relativeHumidity", "relative humidity (%)")]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("density", "density (kg/m3)")]
-        public static double DensityRelativeHumidity(double dryBulbTemperature, double relativeHumidity, double pressure)
+        [Input("pressure", "pressure (Pa) [(Psi)]")]
+        [Output("density", "density (kg/m3) [lb/ft3)]")]
+        public static double DensityRelativeHumidity(string unitSystem, double dryBulbTemperature, double relativeHumidity, double pressure)
         {
             relativeHumidity = relativeHumidity / 100;
-            PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);            
-            double humidityRatio = psy.GetHumRatioFromRelHum(dryBulbTemperature, relativeHumidity, pressure);
-            return psy.GetMoistAirDensity(dryBulbTemperature, humidityRatio, pressure);
+
+            if (unitSystem == "SI" || unitSystem == string.Empty)
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
+                double humidityRatio = psy.GetHumRatioFromRelHum(dryBulbTemperature, relativeHumidity, pressure);
+                return psy.GetMoistAirDensity(dryBulbTemperature, humidityRatio, pressure);
+
+            }
+            else
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.IP);
+                double humidityRatio = psy.GetHumRatioFromRelHum(dryBulbTemperature, relativeHumidity, pressure);
+                return psy.GetMoistAirDensity(dryBulbTemperature, humidityRatio, pressure);
+
+            }
+
         }
     }
 }

--- a/Psychrometrics_Engine/Compute/DensityWetBulbTemperature.cs
+++ b/Psychrometrics_Engine/Compute/DensityWetBulbTemperature.cs
@@ -33,15 +33,29 @@ namespace BH.Engine.Psychrometrics
     public static partial class Compute
     {
         [Description("Calculates density from dry-bulb temperature and wet-bulb temperature.")]
-        [Input("dryBulbTemperature", "dry-bulb temperature (C)")]
-        [Input("wetBulbTemperature", "wet-bulb temperature (C)")]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("density", "density (kg/m3)")]
-        public static double DensityWetBulbTemperature(double dryBulbTemperature, double wetBulbTemperature, double pressure)
+        [Input("unitSystem", "SI [IP]")]
+        [Input("dryBulbTemperature", "dry-bulb temperature (C) [(F)]")]
+        [Input("wetBulbTemperature", "wet-bulb temperature (C) [(F)]")]
+        [Input("pressure", "pressure (Pa) [(Psi)]")]
+        [Output("density", "density (kg/m3) [lb/ft3)]")]
+        public static double DensityWetBulbTemperature(string unitSystem, double dryBulbTemperature, double wetBulbTemperature, double pressure)
         {
-            PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
-            double humidityRatio = psy.GetHumRatioFromTWetBulb(dryBulbTemperature, wetBulbTemperature, pressure);
-            return psy.GetMoistAirDensity(dryBulbTemperature, humidityRatio, pressure);
+
+            if (unitSystem == "SI" || unitSystem == string.Empty)
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
+                double humidityRatio = psy.GetHumRatioFromTWetBulb(dryBulbTemperature, wetBulbTemperature, pressure);
+                return psy.GetMoistAirDensity(dryBulbTemperature, humidityRatio, pressure);
+
+            }
+            else
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.IP);
+                double humidityRatio = psy.GetHumRatioFromTWetBulb(dryBulbTemperature, wetBulbTemperature, pressure);
+                return psy.GetMoistAirDensity(dryBulbTemperature, humidityRatio, pressure);
+
+            }
+
         }
     }
 }

--- a/Psychrometrics_Engine/Compute/DewPointHumidityRatio.cs
+++ b/Psychrometrics_Engine/Compute/DewPointHumidityRatio.cs
@@ -33,14 +33,25 @@ namespace BH.Engine.Psychrometrics
     public static partial class Compute
     {
         [Description("Calculates wet-bulb temperature from dry-bulb temperature and humidity ratio.")]
-        [Input("dryBulbTemperature", "dry-bulb temperature (C)")]
-        [Input("humidityRatio", "humidity ratio (kg_water/kg_dryair)")]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("dewPointTemperature", "dew point temperature (C)")]
-        public static double DewPointHumidityRatio(double dryBulbTemperature, double humidityRatio, double pressure)
+        [Input("unitSystem", "SI [IP]")]
+        [Input("dryBulbTemperature", "dry-bulb temperature (C) [(F)]")]
+        [Input("humidityRatio", "humidity ratio (kg_water/kg_dryair) [(lb_water/lb_dryair)]")]
+        [Input("pressure", "pressure (Pa) [(Psi)]")]
+        [Output("dewPointTemperature", "dew point temperature (C) [(F)]")]
+        public static double DewPointHumidityRatio(string unitSystem, double dryBulbTemperature, double humidityRatio, double pressure)
         {
-            PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
-            return psy.GetTDewPointFromHumRatio(dryBulbTemperature, humidityRatio, pressure);
+            if (unitSystem == "SI" || unitSystem == string.Empty)
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
+                return psy.GetTDewPointFromHumRatio(dryBulbTemperature, humidityRatio, pressure);
+
+            }
+            else
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.IP);
+                return psy.GetTDewPointFromHumRatio(dryBulbTemperature, humidityRatio, pressure);
+
+            }
         }
     }
 }

--- a/Psychrometrics_Engine/Compute/DewPointRelativeHumidity.cs
+++ b/Psychrometrics_Engine/Compute/DewPointRelativeHumidity.cs
@@ -33,16 +33,30 @@ namespace BH.Engine.Psychrometrics
     public static partial class Compute
     {
         [Description("Calculates dew point temperature from dry-bulb temperature and relative humidity.")]
-        [Input("dryBulbTemperature", "dry-bulb temperature (C)")]
+        [Input("unitSystem", "SI [IP]")]
+        [Input("dryBulbTemperature", "dry-bulb temperature (C) [(F)]")]
         [Input("relativeHumidity", "relative humidity (%)")]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("dewPointTemperature", "dew point temperature (C)")]
-        public static double DewPointRelativeHumidity(double dryBulbTemperature, double relativeHumidity, double pressure)
+        [Input("pressure", "pressure (Pa) [(Psi)]")]
+        [Output("dewPointTemperature", "dew point temperature (C) [(F)]")]
+        public static double DewPointRelativeHumidity(string unitSystem, double dryBulbTemperature, double relativeHumidity, double pressure)
         {
             relativeHumidity = relativeHumidity / 100;
-            PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
-            double humidityRatio = psy.GetHumRatioFromRelHum(dryBulbTemperature, relativeHumidity, pressure);
-            return psy.GetTDewPointFromHumRatio(dryBulbTemperature, humidityRatio, pressure);
+
+            if (unitSystem == "SI" || unitSystem == string.Empty)
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
+                double humidityRatio = psy.GetHumRatioFromRelHum(dryBulbTemperature, relativeHumidity, pressure);
+                return psy.GetTDewPointFromHumRatio(dryBulbTemperature, humidityRatio, pressure);
+
+            }
+            else
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.IP);
+                double humidityRatio = psy.GetHumRatioFromRelHum(dryBulbTemperature, relativeHumidity, pressure);
+                return psy.GetTDewPointFromHumRatio(dryBulbTemperature, humidityRatio, pressure);
+
+            }
+
         }
     }
 }

--- a/Psychrometrics_Engine/Compute/DewPointWetBulbTemperature.cs
+++ b/Psychrometrics_Engine/Compute/DewPointWetBulbTemperature.cs
@@ -33,14 +33,25 @@ namespace BH.Engine.Psychrometrics
     public static partial class Compute
     {
         [Description("Calculates dew point temperature from dry-bulb temperature and wet-bulb temperature.")]
-        [Input("dryBulbTemperature", "dry-bulb temperature (C)")]
-        [Input("wetBulbTemperature", "wet-bulb temperature (C)")]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("dewPointTemperature", "dew point temperature (C)")]
-        public static double DewPointWetBulbTemperature(double dryBulbTemperature, double wetBulbTemperature, double pressure)
+        [Input("unitSystem", "SI [IP]")]
+        [Input("dryBulbTemperature", "dry-bulb temperature (C) [(F)]")]
+        [Input("wetBulbTemperature", "wet-bulb temperature (C) [(F)]")]
+        [Input("pressure", "pressure (Pa) [(Psi)]")]
+        [Output("dewPointTemperature", "dew point temperature (C) [(F)]")]
+        public static double DewPointWetBulbTemperature(string unitSystem, double dryBulbTemperature, double wetBulbTemperature, double pressure)
         {
-            PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
-            return psy.GetTDewPointFromTWetBulb(dryBulbTemperature, wetBulbTemperature, pressure);
+            if (unitSystem == "SI" || unitSystem == string.Empty)
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
+                return psy.GetTDewPointFromTWetBulb(dryBulbTemperature, wetBulbTemperature, pressure);
+
+            }
+            else
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.IP);
+                return psy.GetTDewPointFromTWetBulb(dryBulbTemperature, wetBulbTemperature, pressure);
+
+            }
         }
     }
 }

--- a/Psychrometrics_Engine/Compute/EnthalpyHumidityRatio.cs
+++ b/Psychrometrics_Engine/Compute/EnthalpyHumidityRatio.cs
@@ -33,13 +33,23 @@ namespace BH.Engine.Psychrometrics
     public static partial class Compute
     {
         [Description("Calculates enthalpy from dry-bulb temperature and humidity ratio.")]
-        [Input("dryBulbTemperature", "dry-bulb temperature (C)")]
-        [Input("humidityRatio", "humidity ratio (kg_water/kg_dryair)")]
-        [Output("enthalpy", "enthalpy (J/kg)")]
-        public static double EnthalpyHumidityRatio(double dryBulbTemperature, double humidityRatio)
+        [Input("unitSystem", "SI [IP]")]
+        [Input("dryBulbTemperature", "dry-bulb temperature (C) [(F)]")]
+        [Input("humidityRatio", "humidity ratio (kg_water/kg_dryair) [(lb_water/lb_dryair)]")]
+        [Output("enthalpy", "enthalpy (J/kg) [(Btu/lb_dryair)]")]
+        public static double EnthalpyHumidityRatio(string unitSystem, double dryBulbTemperature, double humidityRatio)
         {
-            PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
-            return psy.GetMoistAirEnthalpy(dryBulbTemperature, humidityRatio);
+            if (unitSystem == "SI" || unitSystem == string.Empty)
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
+                return psy.GetMoistAirEnthalpy(dryBulbTemperature, humidityRatio);
+            }
+            else
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.IP);
+                return psy.GetMoistAirEnthalpy(dryBulbTemperature, humidityRatio);
+            }
+
         }
     }
 }

--- a/Psychrometrics_Engine/Compute/EnthalpyRelativeHumidity.cs
+++ b/Psychrometrics_Engine/Compute/EnthalpyRelativeHumidity.cs
@@ -33,16 +33,29 @@ namespace BH.Engine.Psychrometrics
     public static partial class Compute
     {
         [Description("Calculates enthalpy from dry-bulb temperature and relative humidity.")]
-        [Input("dryBulbTemperature", "dry-bulb temperature (C)")]
+        [Input("unitSystem", "SI [IP]")]
+        [Input("dryBulbTemperature", "dry-bulb temperature (C) [(F)]")]
         [Input("relativeHumidity", "relative humidity (%)")]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("enthalpy", "enthalpy (J/kg)")]
-        public static double EnthalpyRelativeHumidity(double dryBulbTemperature, double relativeHumidity, double pressure)
+        [Input("pressure", "pressure (Pa) [(Psi)]")]
+        [Output("enthalpy", "enthalpy (J/kg) [(Btu/lb_dryair)]")]
+        public static double EnthalpyRelativeHumidity(string unitSystem, double dryBulbTemperature, double relativeHumidity, double pressure)
         {
             relativeHumidity = relativeHumidity / 100;
-            PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
-            double humidityRatio = psy.GetHumRatioFromRelHum(dryBulbTemperature, relativeHumidity, pressure);
-            return psy.GetMoistAirEnthalpy(dryBulbTemperature, humidityRatio);
+            if (unitSystem == "SI" || unitSystem == string.Empty)
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
+                double humidityRatio = psy.GetHumRatioFromRelHum(dryBulbTemperature, relativeHumidity, pressure);
+                return psy.GetMoistAirEnthalpy(dryBulbTemperature, humidityRatio);
+
+            }
+            else
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.IP);
+                double humidityRatio = psy.GetHumRatioFromRelHum(dryBulbTemperature, relativeHumidity, pressure);
+                return psy.GetMoistAirEnthalpy(dryBulbTemperature, humidityRatio);
+
+            }
+
         }
     }
 }

--- a/Psychrometrics_Engine/Compute/EnthalpyWetBulbTemperature.cs
+++ b/Psychrometrics_Engine/Compute/EnthalpyWetBulbTemperature.cs
@@ -33,15 +33,29 @@ namespace BH.Engine.Psychrometrics
     public static partial class Compute
     {
         [Description("Calculates enthalpy from dry-bulb temperature and wet-bulb temperature.")]
-        [Input("dryBulbTemperature", "dry-bulb temperature (C)")]
-        [Input("wetBulbTemperature", "wet-bulb temperature (C)")]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("enthalpy", "enthalpy (J/kg)")]
-        public static double EnthalpyWetBulbTemperature(double dryBulbTemperature, double wetBulbTemperature, double pressure)
+        [Input("unitSystem", "SI [IP]")]
+        [Input("dryBulbTemperature", "dry-bulb temperature (C) [(F)]")]
+        [Input("wetBulbTemperature", "wet-bulb temperature (C) [(F)]")]
+        [Input("pressure", "pressure (Pa) [(Psi)]")]
+        [Output("enthalpy", "enthalpy (J/kg) [(Btu/lb_dryair)]")]
+        public static double EnthalpyWetBulbTemperature(string unitSystem, double dryBulbTemperature, double wetBulbTemperature, double pressure)
         {
-            PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
-            double humidityRatio = psy.GetHumRatioFromTWetBulb(dryBulbTemperature, wetBulbTemperature, pressure);
-            return psy.GetMoistAirEnthalpy(dryBulbTemperature, humidityRatio);
+
+            if (unitSystem == "SI" || unitSystem == string.Empty)
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
+                double humidityRatio = psy.GetHumRatioFromTWetBulb(dryBulbTemperature, wetBulbTemperature, pressure);
+                return psy.GetMoistAirEnthalpy(dryBulbTemperature, humidityRatio);
+
+            }
+            else
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.IP);
+                double humidityRatio = psy.GetHumRatioFromTWetBulb(dryBulbTemperature, wetBulbTemperature, pressure);
+                return psy.GetMoistAirEnthalpy(dryBulbTemperature, humidityRatio);
+
+            }
+
         }
     }
 }

--- a/Psychrometrics_Engine/Compute/HumidityRatioRelativeHumidity.cs
+++ b/Psychrometrics_Engine/Compute/HumidityRatioRelativeHumidity.cs
@@ -33,15 +33,27 @@ namespace BH.Engine.Psychrometrics
     public static partial class Compute
     {
         [Description("Calculates humidity ratio from dry-bulb temperature and relative humidity.")]
-        [Input("dryBulbTemperature", "dry-bulb temperature (C)")]
+        [Input("unitSystem", "SI [IP]")]
+        [Input("dryBulbTemperature", "dry-bulb temperature (C) [(F)]")]
         [Input("relativeHumidity", "relative humidity (%)")]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("humidityRatio", "humidity ratio (kg_water/kg_dryair)")]
-        public static double HumidityRatioRelativeHumidity(double dryBulbTemperature, double relativeHumidity, double pressure)
+        [Input("pressure", "pressure (Pa) [(Psi)]")]
+        [Output("humidityRatio", "humidity ratio (kg_water/kg_dryair) [(lb_water/lb_dryair)]")]
+        public static double HumidityRatioRelativeHumidity(string unitSystem, double dryBulbTemperature, double relativeHumidity, double pressure)
         {
             relativeHumidity = relativeHumidity / 100;
-            PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
-            return psy.GetHumRatioFromRelHum(dryBulbTemperature, relativeHumidity, pressure);
+
+            if (unitSystem == "SI" || unitSystem == string.Empty)
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
+                return psy.GetHumRatioFromRelHum(dryBulbTemperature, relativeHumidity, pressure);
+
+            }
+            else
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.IP);
+                return psy.GetHumRatioFromRelHum(dryBulbTemperature, relativeHumidity, pressure);
+
+            }
         }
     }
 }

--- a/Psychrometrics_Engine/Compute/HumidityRatioWetBulbTemperature.cs
+++ b/Psychrometrics_Engine/Compute/HumidityRatioWetBulbTemperature.cs
@@ -33,14 +33,25 @@ namespace BH.Engine.Psychrometrics
     public static partial class Compute
     {
         [Description("Calculates humidity ratio from dry-bulb temperature and wet-bulb temperature.")]
-        [Input("dryBulbTemperature", "dry-bulb temperature (C)")]
-        [Input("wetBulbTemperature", "wet-bulb temperature (C)")]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("humidityRatio", "humidity ratio (kg_water/kg_dryair)")]
-        public static double HumidityRatioWetBulbTemperature(double dryBulbTemperature, double wetBulbTemperature, double pressure)
+        [Input("unitSystem", "SI [IP]")]
+        [Input("dryBulbTemperature", "dry-bulb temperature (C) [(F)]")]
+        [Input("wetBulbTemperature", "wet-bulb temperature (C) [(F)]")]
+        [Input("pressure", "pressure (Pa) [(Psi)]")]
+        [Output("humidityRatio", "humidity ratio (kg_water/kg_dryair) [(lb_water/lb_dryair)]")]
+        public static double HumidityRatioWetBulbTemperature(string unitSystem, double dryBulbTemperature, double wetBulbTemperature, double pressure)
         {
-            PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
-            return psy.GetHumRatioFromTWetBulb(dryBulbTemperature, wetBulbTemperature, pressure);
+            if (unitSystem == "SI" || unitSystem == string.Empty)
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
+                return psy.GetHumRatioFromTWetBulb(dryBulbTemperature, wetBulbTemperature, pressure);
+
+            }
+            else
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.IP);
+                return psy.GetHumRatioFromTWetBulb(dryBulbTemperature, wetBulbTemperature, pressure);
+
+            }
         }
     }
 }

--- a/Psychrometrics_Engine/Compute/PartialVapourPressure.cs
+++ b/Psychrometrics_Engine/Compute/PartialVapourPressure.cs
@@ -32,13 +32,23 @@ namespace BH.Engine.Psychrometrics
 {
     public static partial class Compute
     {
-        [Description("Calculates saturation pressure over liquid water for the temperature range -100C to 200C.")]
-        [Input("dryBulbTemperature", "dry-bulb temperature (C)")]
-        [Output("saturationPressure", "saturation pressure (Pa)")]
-        public static double PartialVapourPressure(double dryBulbTemperature)
+        [Description("Calculates saturation pressure over liquid water for the temperature range -100C to 200C. [-148F to 392F]")]
+        [Input("unitSystem", "SI [IP]")]
+        [Input("dryBulbTemperature", "dry-bulb temperature (C) [(F)]")]
+        [Output("saturationPressure", "saturation pressure (Pa) [(Psi)]")]
+        public static double PartialVapourPressure(string unitSystem, double dryBulbTemperature)
         {
-            PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
-            return psy.GetSatVapPres(dryBulbTemperature);
+            if (unitSystem == "SI" || unitSystem == string.Empty)
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
+                return psy.GetSatVapPres(dryBulbTemperature);
+            }
+            else
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.IP);
+                return psy.GetSatVapPres(dryBulbTemperature);
+            }
+            
         }
     }
 }

--- a/Psychrometrics_Engine/Compute/PressureAtAltitude.cs
+++ b/Psychrometrics_Engine/Compute/PressureAtAltitude.cs
@@ -33,12 +33,22 @@ namespace BH.Engine.Psychrometrics
     public static partial class Compute
     {
         [Description("Calculates atmospheric pressure as a function of altitude.")]
-        [Input("altitude", "altitude (m)")]
-        [Output("atmosphericPressure", "atmospheric pressure (Pa)")]
-        public static double PressureAtAltitude(double altitude)
+        [Input("unitSystem", "SI [IP]")]
+        [Input("altitude", "altitude (m) [(ft)]")]
+        [Output("atmosphericPressure", "atmospheric pressure (Pa) [(Psi)]")]
+        public static double PressureAtAltitude(string unitSystem, double altitude)
         {
-            PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
-            return psy.GetStandardAtmPressure(altitude);
+            if (unitSystem == "SI" || unitSystem == string.Empty)
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
+                return psy.GetStandardAtmPressure(altitude);
+            }
+            else
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.IP);
+                return psy.GetStandardAtmPressure(altitude);
+            }
+
         }
     }
 }

--- a/Psychrometrics_Engine/Compute/RelativeHumidityHumidityRatio.cs
+++ b/Psychrometrics_Engine/Compute/RelativeHumidityHumidityRatio.cs
@@ -33,14 +33,24 @@ namespace BH.Engine.Psychrometrics
     public static partial class Compute
     {
         [Description("Calculates relative humidity from dry-bulb temperature and humidity ratio.")]
-        [Input("dryBulbTemperature", "dry-bulb temperature (C)")]
-        [Input("humidityRatio", "humidity ratio (kg_water/kg_dryair)")]
-        [Input("pressure", "pressure (Pa)")]
+        [Input("unitSystem", "SI [IP]")]
+        [Input("dryBulbTemperature", "dry-bulb temperature (C) [(F)]")]
+        [Input("humidityRatio", "humidity ratio (kg_water/kg_dryair) [(lb_water/lb_dryair)]")]
+        [Input("pressure", "pressure (Pa) [(Psi)]")]
         [Output("relativeHumidity", "relative humidity (%)")]
-        public static double RelativeHumidityHumidityRatio(double dryBulbTemperature, double humidityRatio, double pressure)
+        public static double RelativeHumidityHumidityRatio(string unitSystem, double dryBulbTemperature, double humidityRatio, double pressure)
         {
-            PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
-            return psy.GetRelHumFromHumRatio(dryBulbTemperature, humidityRatio, pressure) * 100;
+            if (unitSystem == "SI" || unitSystem == string.Empty)
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
+                return psy.GetRelHumFromHumRatio(dryBulbTemperature, humidityRatio, pressure) * 100;
+            }
+            else
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.IP);
+                return psy.GetRelHumFromHumRatio(dryBulbTemperature, humidityRatio, pressure) * 100;
+            }
+
         }
     }
 }

--- a/Psychrometrics_Engine/Compute/RelativeHumidityWetBulbTemperature.cs
+++ b/Psychrometrics_Engine/Compute/RelativeHumidityWetBulbTemperature.cs
@@ -33,14 +33,24 @@ namespace BH.Engine.Psychrometrics
     public static partial class Compute
     {
         [Description("Calculates relative humidity from dry-bulb temperature and wet-bulb temperature.")]
-        [Input("dryBulbTemperature", "dry-bulb temperature (C)")]
-        [Input("wetBulbTemperature", "wet-bulb temperature (C)")]
-        [Input("pressure", "pressure (Pa)")]
+        [Input("unitSystem", "SI [IP]")]
+        [Input("dryBulbTemperature", "dry-bulb temperature (C) [(F)]")]
+        [Input("wetBulbTemperature", "wet-bulb temperature (C) [(F)]")]
+        [Input("pressure", "pressure (Pa) [(Psi)]")]
         [Output("relativeHumidity", "relative humidity (%)")]
-        public static double RelativeHumidityWetBulbTemperature(double dryBulbTemperature, double wetBulbTemperature, double pressure)
+        public static double RelativeHumidityWetBulbTemperature(string unitSystem, double dryBulbTemperature, double wetBulbTemperature, double pressure)
         {
-            PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
-            return psy.GetRelHumFromTWetBulb(dryBulbTemperature, wetBulbTemperature, pressure) * 100;
+            if (unitSystem == "SI" || unitSystem == string.Empty)
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
+                return psy.GetRelHumFromTWetBulb(dryBulbTemperature, wetBulbTemperature, pressure) * 100;
+            }
+            else
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.IP);
+                return psy.GetRelHumFromTWetBulb(dryBulbTemperature, wetBulbTemperature, pressure) * 100;
+            }
+
         }
     }
 }

--- a/Psychrometrics_Engine/Compute/SpecificVolumeHumidityRatio.cs
+++ b/Psychrometrics_Engine/Compute/SpecificVolumeHumidityRatio.cs
@@ -33,14 +33,24 @@ namespace BH.Engine.Psychrometrics
     public static partial class Compute
     {
         [Description("Calculates specific volume from dry-bulb temperature and humidity ratio.")]
-        [Input("dryBulbTemperature", "dry-bulb temperature (C)")]
-        [Input("humidityRatio", "humidity ratio (kg_water/kg_dryair)")]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("specificVolume", "specificVolume(m3/kg)")]
-        public static double SpecificVolumeHumidityRatio(double dryBulbTemperature, double humidityRatio, double pressure)
+        [Input("unitSystem", "SI [IP]")]
+        [Input("dryBulbTemperature", "dry-bulb temperature (C) [(F)]")]
+        [Input("humidityRatio", "humidity ratio (kg_water/kg_dryair) [(lb_water/lb_dryair)]")]
+        [Input("pressure", "pressure (Pa) [(Psi)]")]
+        [Output("specificVolume", "specificVolume(m3/kg) [(ft3/lb)]")]
+        public static double SpecificVolumeHumidityRatio(string unitSystem, double dryBulbTemperature, double humidityRatio, double pressure)
         {
-            PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
-            return psy.GetMoistAirVolume(dryBulbTemperature, humidityRatio, pressure);
+            if (unitSystem == "SI" || unitSystem == string.Empty)
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
+                return psy.GetMoistAirVolume(dryBulbTemperature, humidityRatio, pressure);
+            }
+            else
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.IP);
+                return psy.GetMoistAirVolume(dryBulbTemperature, humidityRatio, pressure);
+            }
+
         }
     }
 }

--- a/Psychrometrics_Engine/Compute/SpecificVolumeRelativeHumidity.cs
+++ b/Psychrometrics_Engine/Compute/SpecificVolumeRelativeHumidity.cs
@@ -33,16 +33,28 @@ namespace BH.Engine.Psychrometrics
     public static partial class Compute
     {
         [Description("Calculates specific volume from dry-bulb temperature and relative humidity.")]
-        [Input("dryBulbTemperature", "dry-bulb temperature (C)")]
+        [Input("unitSystem", "SI [IP]")]
+        [Input("dryBulbTemperature", "dry-bulb temperature (C) [(F)]")]
         [Input("relativeHumidity", "relative humidity (%)")]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("specificVolume", "specific volume(m3/kg)")]
-        public static double SpecificVolumeRelativeHumidity(double dryBulbTemperature, double relativeHumidity, double pressure)
+        [Input("pressure", "pressure (Pa) [(Psi)]")]
+        [Output("specificVolume", "specific volume(m3/kg) [(ft3/lb)]")]
+        public static double SpecificVolumeRelativeHumidity(string unitSystem, double dryBulbTemperature, double relativeHumidity, double pressure)
         {
             relativeHumidity = relativeHumidity / 100;
-            PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
-            double humidityRatio = psy.GetHumRatioFromRelHum(dryBulbTemperature, relativeHumidity, pressure);
-            return psy.GetMoistAirVolume(dryBulbTemperature, humidityRatio, pressure);
+
+            if (unitSystem == "SI" || unitSystem == string.Empty)
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
+                double humidityRatio = psy.GetHumRatioFromRelHum(dryBulbTemperature, relativeHumidity, pressure);
+                return psy.GetMoistAirVolume(dryBulbTemperature, humidityRatio, pressure);
+            }
+            else
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.IP);
+                double humidityRatio = psy.GetHumRatioFromRelHum(dryBulbTemperature, relativeHumidity, pressure);
+                return psy.GetMoistAirVolume(dryBulbTemperature, humidityRatio, pressure);
+            }
+
         }
     }
 }

--- a/Psychrometrics_Engine/Compute/SpecificVolumeWetBulbTemperature.cs
+++ b/Psychrometrics_Engine/Compute/SpecificVolumeWetBulbTemperature.cs
@@ -33,15 +33,26 @@ namespace BH.Engine.Psychrometrics
     public static partial class Compute
     {
         [Description("Calculates specific volume from dry-bulb temperature and wet-bulb temperature.")]
-        [Input("dryBulbTemperature", "dry-bulb temperature (C)")]
-        [Input("wetBulbTemperature", "wet-bulb temperature (C)")]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("specificVolume", "specific volume(m3/kg)")]
-        public static double SpecificVolumeWetBulbTemperature(double dryBulbTemperature, double wetBulbTemperature, double pressure)
+        [Input("unitSystem", "SI [IP]")]
+        [Input("dryBulbTemperature", "dry-bulb temperature (C) [(F)]")]
+        [Input("wetBulbTemperature", "wet-bulb temperature (C) [(F)]")]
+        [Input("pressure", "pressure (Pa) [(Psi)]")]
+        [Output("specificVolume", "specific volume(m3/kg) [(ft3/lb)]")]
+        public static double SpecificVolumeWetBulbTemperature(string unitSystem, double dryBulbTemperature, double wetBulbTemperature, double pressure)
         {
-            PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
-            double humidityRatio = psy.GetHumRatioFromTWetBulb(dryBulbTemperature, wetBulbTemperature, pressure);
-            return psy.GetMoistAirVolume(dryBulbTemperature, humidityRatio, pressure);
+            if (unitSystem == "SI" || unitSystem == string.Empty)
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
+                double humidityRatio = psy.GetHumRatioFromTWetBulb(dryBulbTemperature, wetBulbTemperature, pressure);
+                return psy.GetMoistAirVolume(dryBulbTemperature, humidityRatio, pressure);
+            }
+            else
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.IP);
+                double humidityRatio = psy.GetHumRatioFromTWetBulb(dryBulbTemperature, wetBulbTemperature, pressure);
+                return psy.GetMoistAirVolume(dryBulbTemperature, humidityRatio, pressure);
+            }
+
         }
     }
 }

--- a/Psychrometrics_Engine/Compute/TemperatureAtAltitude.cs
+++ b/Psychrometrics_Engine/Compute/TemperatureAtAltitude.cs
@@ -33,12 +33,22 @@ namespace BH.Engine.Psychrometrics
     public static partial class Compute
     {
         [Description("Calculates temperature as a function of altitude.")]
-        [Input("altitude", "altitude (m)")]
-        [Output("temperature", "temperature (C)")]
-        public static double TemperatureAtAltitude(double altitude)
+        [Input("unitSystem", "SI [IP]")]
+        [Input("altitude", "altitude (m) [(ft)]")]
+        [Output("temperature", "temperature (C) [(F)]")]
+        public static double TemperatureAtAltitude(string unitSystem, double altitude)
         {
-            PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
-            return psy.GetStandardAtmTemperature(altitude);
+            if (unitSystem == "SI" || unitSystem == string.Empty)
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
+                return psy.GetStandardAtmTemperature(altitude);
+            }
+            else
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.IP);
+                return psy.GetStandardAtmTemperature(altitude);
+            }
+
         }
     }
 }

--- a/Psychrometrics_Engine/Compute/TemperatureEnthalpyHumidityRatio.cs
+++ b/Psychrometrics_Engine/Compute/TemperatureEnthalpyHumidityRatio.cs
@@ -33,13 +33,23 @@ namespace BH.Engine.Psychrometrics
     public static partial class Compute
     {
         [Description("Calculates temperature as a function of enthalpy.")]
-        [Input("enthalpy", "enthalpy (J/kg)")]
-        [Input("humidityRatio", "humidity ratio (g/g)")]
-        [Output("temperature", "temperature (C)")]
-        public static double TemperatureEnthalpyHumidityRatio(double enthalpy, double humidityRatio)
+        [Input("unitSystem", "SI [IP]")]
+        [Input("enthalpy", "enthalpy (J/kg) [(Btu/lb_dryair)]")]
+        [Input("humidityRatio", "humidity ratio (kg_water/kg_dryair) [(lb_water/lb_dryair)]")]
+        [Output("temperature", "temperature (C) [(F)]")]
+        public static double TemperatureEnthalpyHumidityRatio(string unitSystem, double enthalpy, double humidityRatio)
         {
-            PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
-            return psy.GetTDryBulbFromEnthalpyAndHumRatio(enthalpy, humidityRatio);
+            if (unitSystem == "SI" || unitSystem == string.Empty)
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
+                return psy.GetTDryBulbFromEnthalpyAndHumRatio(enthalpy, humidityRatio);
+            }
+            else
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.IP);
+                return psy.GetTDryBulbFromEnthalpyAndHumRatio(enthalpy, humidityRatio);
+            }
+
         }
     }
 }

--- a/Psychrometrics_Engine/Compute/WetBulbHumidityRatio.cs
+++ b/Psychrometrics_Engine/Compute/WetBulbHumidityRatio.cs
@@ -33,14 +33,24 @@ namespace BH.Engine.Psychrometrics
     public static partial class Compute
     {
         [Description("Calculates wet-bulb temperature from dry-bulb temperature and humidity ratio.")]
-        [Input("dryBulbTemperature", "dry-bulb temperature (C)")]
-        [Input("humidityRatio", "humidity ratio (kg_water/kg_dryair)")]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("wetBulbTemperature", "wet-bulb temperature (C)")]
-        public static double WetBulbHumidityRatio(double dryBulbTemperature, double humidityRatio, double pressure)
+        [Input("unitSystem", "SI [IP]")]
+        [Input("dryBulbTemperature", "dry-bulb temperature (C) [(F)]")]
+        [Input("humidityRatio", "humidity ratio (kg_water/kg_dryair) [(lb_water/lb_dryair)]")]
+        [Input("pressure", "pressure (Pa) [(Psi)]")]
+        [Output("wetBulbTemperature", "wet-bulb temperature (C) [(F)]")]
+        public static double WetBulbHumidityRatio(string unitSystem, double dryBulbTemperature, double humidityRatio, double pressure)
         {
-            PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
-            return psy.GetTWetBulbFromHumRatio(dryBulbTemperature, humidityRatio, pressure);
+            if (unitSystem == "SI" || unitSystem == string.Empty)
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
+                return psy.GetTWetBulbFromHumRatio(dryBulbTemperature, humidityRatio, pressure);
+            }
+            else
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.IP);
+                return psy.GetTWetBulbFromHumRatio(dryBulbTemperature, humidityRatio, pressure);
+            }
+
         }
     }
 }

--- a/Psychrometrics_Engine/Compute/WetBulbTemperatureRelativeHumidity.cs
+++ b/Psychrometrics_Engine/Compute/WetBulbTemperatureRelativeHumidity.cs
@@ -33,15 +33,26 @@ namespace BH.Engine.Psychrometrics
     public static partial class Compute
     {
         [Description("Calculates wet-bulb temperature from dry-bulb temperature and relative humidity.")]
-        [Input("dryBulbTemperature", "dry-bulb temperature (C)")]
+        [Input("unitSystem", "SI [IP]")]
+        [Input("dryBulbTemperature", "dry-bulb temperature (C) [(F)]")]
         [Input("relativeHumidity", "relative humidity (%)")]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("wetBulbTemperature", "wet-bulb temperature (C)")]
-        public static double WetBulbTemperatureRelativeHumidity(double dryBulbTemperature, double relativeHumidity, double pressure)
+        [Input("pressure", "pressure (Pa) [(Psi)]")]
+        [Output("wetBulbTemperature", "wet-bulb temperature (C) [(F)]")]
+        public static double WetBulbTemperatureRelativeHumidity(string unitSystem, double dryBulbTemperature, double relativeHumidity, double pressure)
         {
             relativeHumidity = relativeHumidity / 100;
-            PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
-            return psy.GetTWetBulbFromRelHum(dryBulbTemperature, relativeHumidity, pressure);
+
+            if (unitSystem == "SI" || unitSystem == string.Empty)
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
+                return psy.GetTWetBulbFromRelHum(dryBulbTemperature, relativeHumidity, pressure);
+            }
+            else
+            {
+                PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.IP);
+                return psy.GetTWetBulbFromRelHum(dryBulbTemperature, relativeHumidity, pressure);
+            }
+
         }
     }
 }


### PR DESCRIPTION
Default unit system remains as SI, however users can now input IP into each equation rather than needing to convert inputs prior to running calculation.

Updated units for SI to reflect what is used in the wrapped PsychroLib. Original script had humidity ratio as g/g, while  kgwater/kgair  is used in PsychroLib. Since humidity ratio is a unitless number this is functionally the same. This change can be reverted without issue.

### Changelog
Added support for IP Unit System
