### PR TITLE
Compliance and spelling issues fixed

### DIFF
--- a/Psychrometrics_Engine/Compute/DensityHumidityRatio.cs
+++ b/Psychrometrics_Engine/Compute/DensityHumidityRatio.cs
@@ -31,15 +31,15 @@ namespace BH.Engine.Psychrometrics
     {
         [Description("Calculates density from dry-bulb temperature and humidity ratio.")]
         [Input("dryBulbTemperature", "Dry-bulb temperature.", typeof(Temperature))]
-        [Input("humidityRatio", "humidity ratio (kg_water/kg_dryair).")]
-        [Input("pressure", "pressure (Pa).")]
-        [Output("density", "density(kg/m3).")]
+        [Input("humidityRatio", "Humidity ratio (kg_water/kg_dryair).", typeof(Ratio))]
+        [Input("pressure", "Pressure.", typeof(Pressure))]
+        [Output("density", "Density.", typeof(Density))]
         public static double DensityHumidityRatio(double dryBulbTemperature, double humidityRatio, double pressure)
         {
             if (dryBulbTemperature < 100)
             {
                 // This warning is added because this method used to take dryBulbTemperature in C.
-                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celcius/Fahrenheit instead of Kelvin. Check your inputs.");
+                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celsius/Fahrenheit instead of Kelvin. Check your inputs.");
             }
             PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
             return psy.GetMoistAirDensity(dryBulbTemperature.ToDegreeCelsius(), humidityRatio, pressure);

--- a/Psychrometrics_Engine/Compute/DensityRelativeHumidity.cs
+++ b/Psychrometrics_Engine/Compute/DensityRelativeHumidity.cs
@@ -31,17 +31,17 @@ namespace BH.Engine.Psychrometrics
     {
         [Description("Calculates density from dry-bulb temperature and relative humidity.")]
         [Input("dryBulbTemperature", "Dry-bulb temperature.", typeof(Temperature))]
-        [Input("relativeHumidity", "relative humidity (%)")]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("density", "density (kg/m3)")]
+        [Input("relativeHumidity", "Relative humidity (%).")]
+        [Input("pressure", "Pressure.", typeof(Pressure))]
+        [Output("density", "Density.", typeof(Density))]
         public static double DensityRelativeHumidity(double dryBulbTemperature, double relativeHumidity, double pressure)
         {
             if (dryBulbTemperature < 100)
             {
                 // This warning is added because this method used to take dryBulbTemperature in C.
-                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celcius/Fahrenheit instead of Kelvin. Check your inputs.");
+                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celsius/Fahrenheit instead of Kelvin. Check your inputs.");
             }
-            relativeHumidity = relativeHumidity / 100;
+            relativeHumidity /= 100;
             PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
             double humidityRatio = psy.GetHumRatioFromRelHum(dryBulbTemperature.ToDegreeCelsius(), relativeHumidity, pressure);
             return psy.GetMoistAirDensity(dryBulbTemperature.ToDegreeCelsius(), humidityRatio, pressure);

--- a/Psychrometrics_Engine/Compute/DensityWater.cs
+++ b/Psychrometrics_Engine/Compute/DensityWater.cs
@@ -37,7 +37,7 @@ namespace BH.Engine.Psychrometrics
     public static partial class Compute
     {
         [Description("Calculates water density from temperature.")]
-        [Input("temperature", "Water Temperature.", typeof(Temperature))]
+        [Input("temperature", "Water temperature.", typeof(Temperature))]
         [Output("density", "Density.", typeof(Density))]
         public static double DensityWater(double temperature)
         {

--- a/Psychrometrics_Engine/Compute/DensityWetBulbTemperature.cs
+++ b/Psychrometrics_Engine/Compute/DensityWetBulbTemperature.cs
@@ -32,14 +32,14 @@ namespace BH.Engine.Psychrometrics
         [Description("Calculates density from dry-bulb temperature and wet-bulb temperature.")]
         [Input("dryBulbTemperature", "Dry-bulb temperature.", typeof(Temperature))]
         [Input("wetBulbTemperature", "Wet-bulb temperature.", typeof(Temperature))]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("density", "density (kg/m3)")]
+        [Input("pressure", "Pressure.", typeof(Pressure))]
+        [Output("density", "Density.", typeof(Density))]
         public static double DensityWetBulbTemperature(double dryBulbTemperature, double wetBulbTemperature, double pressure)
         {
             if (dryBulbTemperature < 100 || wetBulbTemperature < 100)
             {
                 // This warning is added because this method used to take temperatures in C.
-                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celcius/Fahrenheit instead of Kelvin. Check your inputs.");
+                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celsius/Fahrenheit instead of Kelvin. Check your inputs.");
             }
             PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
             double humidityRatio = psy.GetHumRatioFromTWetBulb(dryBulbTemperature.ToDegreeCelsius(), wetBulbTemperature.ToDegreeCelsius(), pressure);

--- a/Psychrometrics_Engine/Compute/DewPointHumidityRatio.cs
+++ b/Psychrometrics_Engine/Compute/DewPointHumidityRatio.cs
@@ -29,17 +29,17 @@ namespace BH.Engine.Psychrometrics
 {
     public static partial class Compute
     {
-        [Description("Calculates wet-bulb temperature from dry-bulb temperature and humidity ratio.")]
+        [Description("Calculates dew point temperature from dry-bulb temperature and humidity ratio.")]
         [Input("dryBulbTemperature", "Dry-bulb temperature.", typeof(Temperature))]
-        [Input("humidityRatio", "humidity ratio (kg_water/kg_dryair)")]
-        [Input("pressure", "pressure (Pa)")]
+        [Input("humidityRatio", "Humidity ratio (kg_water/kg_dryair).", typeof(Ratio))]
+        [Input("pressure", "Pressure.", typeof(Pressure))]
         [Output("dewPointTemperature", "Dew point temperature.", typeof(Temperature))]
         public static double DewPointHumidityRatio(double dryBulbTemperature, double humidityRatio, double pressure)
         {
             if (dryBulbTemperature < 100)
             {
                 // This warning is added because this method used to take dryBulbTemperature in C.
-                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celcius/Fahrenheit instead of Kelvin. Check your inputs.");
+                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celsius/Fahrenheit instead of Kelvin. Check your inputs.");
             }
             PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
             return psy.GetTDewPointFromHumRatio(dryBulbTemperature.ToDegreeCelsius(), humidityRatio, pressure).FromDegreeCelsius();

--- a/Psychrometrics_Engine/Compute/DewPointRelativeHumidity.cs
+++ b/Psychrometrics_Engine/Compute/DewPointRelativeHumidity.cs
@@ -35,8 +35,8 @@ namespace BH.Engine.Psychrometrics
     public static partial class Compute
     {
         [Description("Calculates dew point temperature from dry-bulb temperature and relative humidity.")]
-        [Input("dryBulbTemperature", "Dry bulb temperature.", typeof(Temperature))]
-        [Input("relativeHumidity", "Relative humidity (%).", typeof(double))]
+        [Input("dryBulbTemperature", "Dry-bulb temperature.", typeof(Temperature))]
+        [Input("relativeHumidity", "Relative humidity (%).")]
         [Input("pressure", "Pressure.", typeof(Pressure))]
         [Output("dewPointTemperature", "Dew point temperature.", typeof(Temperature))]
         public static double DewPointRelativeHumidity(double dryBulbTemperature, double relativeHumidity, double pressure)
@@ -44,7 +44,7 @@ namespace BH.Engine.Psychrometrics
             if (dryBulbTemperature < 100)
             {
                 // This warning is added because this method used to take dryBulbTemperature in C. 
-                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celcius/Fahrenheit instead of Kelvin. Check your inputs.");
+                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celsius/Fahrenheit instead of Kelvin. Check your inputs.");
             }
             relativeHumidity = relativeHumidity / 100;
             PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);

--- a/Psychrometrics_Engine/Compute/DewPointWetBulbTemperature.cs
+++ b/Psychrometrics_Engine/Compute/DewPointWetBulbTemperature.cs
@@ -32,14 +32,14 @@ namespace BH.Engine.Psychrometrics
         [Description("Calculates dew point temperature from dry-bulb temperature and wet-bulb temperature.")]
         [Input("dryBulbTemperature", "Dry-bulb temperature.", typeof(Temperature))]
         [Input("wetBulbTemperature", "Wet-bulb temperature.", typeof(Temperature))]
-        [Input("pressure", "pressure (Pa)")]
+        [Input("pressure", "Pressure.", typeof(Pressure))]
         [Output("dewPointTemperature", "Dew point temperature.", typeof(Temperature))]
         public static double DewPointWetBulbTemperature(double dryBulbTemperature, double wetBulbTemperature, double pressure)
         {
             if (dryBulbTemperature < 100 || wetBulbTemperature < 100)
             {
                 // This warning is added because this method used to take temperatures in C.
-                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celcius/Fahrenheit instead of Kelvin. Check your inputs.");
+                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celsius/Fahrenheit instead of Kelvin. Check your inputs.");
             }
             PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
             return psy.GetTDewPointFromTWetBulb(dryBulbTemperature.ToDegreeCelsius(), wetBulbTemperature.ToDegreeCelsius(), pressure).FromDegreeCelsius();

--- a/Psychrometrics_Engine/Compute/EnthalpyHumidityRatio.cs
+++ b/Psychrometrics_Engine/Compute/EnthalpyHumidityRatio.cs
@@ -31,14 +31,14 @@ namespace BH.Engine.Psychrometrics
     {
         [Description("Calculates enthalpy from dry-bulb temperature and humidity ratio.")]
         [Input("dryBulbTemperature", "Dry-bulb temperature.", typeof(Temperature))]
-        [Input("humidityRatio", "humidity ratio (kg_water/kg_dryair)")]
-        [Output("enthalpy", "enthalpy (J/kg)")]
+        [Input("humidityRatio", "Humidity ratio (kg_water/kg_dryair).", typeof(Ratio))]
+        [Output("enthalpy", "Enthalpy.", typeof(SpecificEnergy))]
         public static double EnthalpyHumidityRatio(double dryBulbTemperature, double humidityRatio)
         {
             if (dryBulbTemperature < 100)
             {
                 // This warning is added because this method used to take dryBulbTemperature in C.
-                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celcius/Fahrenheit instead of Kelvin. Check your inputs.");
+                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celsius/Fahrenheit instead of Kelvin. Check your inputs.");
             }
             PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
             return psy.GetMoistAirEnthalpy(dryBulbTemperature.ToDegreeCelsius(), humidityRatio);

--- a/Psychrometrics_Engine/Compute/EnthalpyRelativeHumidity.cs
+++ b/Psychrometrics_Engine/Compute/EnthalpyRelativeHumidity.cs
@@ -39,7 +39,7 @@ namespace BH.Engine.Psychrometrics
             if (dryBulbTemperature < 100)
             {
                 // This warning is added because this method used to take dryBulbTemperature in C.
-                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celcius/Fahrenheit instead of Kelvin. Check your inputs.");
+                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celsius/Fahrenheit instead of Kelvin. Check your inputs.");
             }
             relativeHumidity = relativeHumidity / 100;
             PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);

--- a/Psychrometrics_Engine/Compute/EnthalpyWetBulbTemperature.cs
+++ b/Psychrometrics_Engine/Compute/EnthalpyWetBulbTemperature.cs
@@ -32,14 +32,14 @@ namespace BH.Engine.Psychrometrics
         [Description("Calculates enthalpy from dry-bulb temperature and wet-bulb temperature.")]
         [Input("dryBulbTemperature", "Dry-bulb temperature.", typeof(Temperature))]
         [Input("wetBulbTemperature", "Wet-bulb temperature.", typeof(Temperature))]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("enthalpy", "enthalpy (J/kg)")]
+        [Input("pressure", "Pressure.", typeof(Pressure))]
+        [Output("enthalpy", "Enthalpy.", typeof(SpecificEnergy))]
         public static double EnthalpyWetBulbTemperature(double dryBulbTemperature, double wetBulbTemperature, double pressure)
         {
             if (dryBulbTemperature < 100 || wetBulbTemperature < 100)
             {
                 // This warning is added because this method used to take temperatures in C.
-                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celcius/Fahrenheit instead of Kelvin. Check your inputs.");
+                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celsius/Fahrenheit instead of Kelvin. Check your inputs.");
             }
             PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
             double humidityRatio = psy.GetHumRatioFromTWetBulb(dryBulbTemperature.ToDegreeCelsius(), wetBulbTemperature.ToDegreeCelsius(), pressure);

--- a/Psychrometrics_Engine/Compute/HumidityRatioRelativeHumidity.cs
+++ b/Psychrometrics_Engine/Compute/HumidityRatioRelativeHumidity.cs
@@ -31,17 +31,17 @@ namespace BH.Engine.Psychrometrics
     {
         [Description("Calculates humidity ratio from dry-bulb temperature and relative humidity.")]
         [Input("dryBulbTemperature", "Dry-bulb temperature.", typeof(Temperature))]
-        [Input("relativeHumidity", "relative humidity (%)")]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("humidityRatio", "humidity ratio (kg_water/kg_dryair)")]
+        [Input("relativeHumidity", "Relative humidity (%).")]
+        [Input("pressure", "Pressure.", typeof(Pressure))]
+        [Output("humidityRatio", "Humidity ratio (kg_water/kg_dryair).", typeof(Ratio))]
         public static double HumidityRatioRelativeHumidity(double dryBulbTemperature, double relativeHumidity, double pressure)
         {
             if (dryBulbTemperature < 100)
             {
                 // This warning is added because this method used to take dryBulbTemperature in C.
-                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celcius/Fahrenheit instead of Kelvin. Check your inputs.");
+                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celsius/Fahrenheit instead of Kelvin. Check your inputs.");
             }
-            relativeHumidity = relativeHumidity / 100;
+            relativeHumidity /= 100;
             PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
             return psy.GetHumRatioFromRelHum(dryBulbTemperature.ToDegreeCelsius(), relativeHumidity, pressure);
         }

--- a/Psychrometrics_Engine/Compute/HumidityRatioWetBulbTemperature.cs
+++ b/Psychrometrics_Engine/Compute/HumidityRatioWetBulbTemperature.cs
@@ -32,14 +32,14 @@ namespace BH.Engine.Psychrometrics
         [Description("Calculates humidity ratio from dry-bulb temperature and wet-bulb temperature.")]
         [Input("dryBulbTemperature", "Dry-bulb temperature.", typeof(Temperature))]
         [Input("wetBulbTemperature", "Wet-bulb temperature.", typeof(Temperature))]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("humidityRatio", "humidity ratio (kg_water/kg_dryair)")]
+        [Input("pressure", "Pressure.", typeof(Pressure))]
+        [Output("humidityRatio", "Humidity ratio (kg_water/kg_dryair).", typeof(Ratio))]
         public static double HumidityRatioWetBulbTemperature(double dryBulbTemperature, double wetBulbTemperature, double pressure)
         {
             if (dryBulbTemperature < 100 || wetBulbTemperature < 100)
             {
                 // This warning is added because this method used to take temperatures in C.
-                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celcius/Fahrenheit instead of Kelvin. Check your inputs.");
+                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celsius/Fahrenheit instead of Kelvin. Check your inputs.");
             }
             PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
             return psy.GetHumRatioFromTWetBulb(dryBulbTemperature.ToDegreeCelsius(), wetBulbTemperature.ToDegreeCelsius(), pressure);

--- a/Psychrometrics_Engine/Compute/PressureAtAltitude.cs
+++ b/Psychrometrics_Engine/Compute/PressureAtAltitude.cs
@@ -34,7 +34,7 @@ namespace BH.Engine.Psychrometrics
     public static partial class Compute
     {
         [Description("Calculates atmospheric pressure as a function of altitude.")]
-        [Input("altitude", "Altitude", typeof(Length))]
+        [Input("altitude", "Altitude.", typeof(Length))]
         [Output("atmosphericPressure", "Atmospheric pressure.", typeof(Pressure))]
         public static double PressureAtAltitude(double altitude)
         {

--- a/Psychrometrics_Engine/Compute/RelativeHumidityHumidityRatio.cs
+++ b/Psychrometrics_Engine/Compute/RelativeHumidityHumidityRatio.cs
@@ -31,15 +31,15 @@ namespace BH.Engine.Psychrometrics
     {
         [Description("Calculates relative humidity from dry-bulb temperature and humidity ratio.")]
         [Input("dryBulbTemperature", "Dry-bulb temperature.", typeof(Temperature))]
-        [Input("humidityRatio", "humidity ratio (kg_water/kg_dryair)")]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("relativeHumidity", "relative humidity (%)")]
+        [Input("humidityRatio", "Humidity ratio (kg_water/kg_dryair).", typeof(Ratio))]
+        [Input("pressure", "Pressure.", typeof(Pressure))]
+        [Output("relativeHumidity", "Relative humidity (%).")]
         public static double RelativeHumidityHumidityRatio(double dryBulbTemperature, double humidityRatio, double pressure)
         {
             if (dryBulbTemperature < 100)
             {
                 // This warning is added because this method used to take dryBulbTemperature in C.
-                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celcius/Fahrenheit instead of Kelvin. Check your inputs.");
+                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celsius/Fahrenheit instead of Kelvin. Check your inputs.");
             }
             PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
             return psy.GetRelHumFromHumRatio(dryBulbTemperature.ToDegreeCelsius(), humidityRatio, pressure) * 100;

--- a/Psychrometrics_Engine/Compute/RelativeHumidityWetBulbTemperature.cs
+++ b/Psychrometrics_Engine/Compute/RelativeHumidityWetBulbTemperature.cs
@@ -32,14 +32,14 @@ namespace BH.Engine.Psychrometrics
         [Description("Calculates relative humidity from dry-bulb temperature and wet-bulb temperature.")]
         [Input("dryBulbTemperature", "Dry-bulb temperature.", typeof(Temperature))]
         [Input("wetBulbTemperature", "Wet-bulb temperature.", typeof(Temperature))]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("relativeHumidity", "relative humidity (%)")]
+        [Input("pressure", "Pressure.", typeof(Pressure))]
+        [Output("relativeHumidity", "Relative humidity (%).")]
         public static double RelativeHumidityWetBulbTemperature(double dryBulbTemperature, double wetBulbTemperature, double pressure)
         {
             if (dryBulbTemperature < 100 || wetBulbTemperature < 100)
             {
                 // This warning is added because this method used to take temperatures in C.
-                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celcius/Fahrenheit instead of Kelvin. Check your inputs.");
+                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celsius/Fahrenheit instead of Kelvin. Check your inputs.");
             }
             PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
             return psy.GetRelHumFromTWetBulb(dryBulbTemperature.ToDegreeCelsius(), wetBulbTemperature.ToDegreeCelsius(), pressure) * 100;

--- a/Psychrometrics_Engine/Compute/SaturatedVapourPressureWater.cs
+++ b/Psychrometrics_Engine/Compute/SaturatedVapourPressureWater.cs
@@ -35,9 +35,9 @@ namespace BH.Engine.Psychrometrics
 {
     public static partial class Compute
     {
-        [Description("Calculates water SaturatedVapourPressure from temperature.")]
-        [Input("temperature", "Water Temperature.", typeof(Temperature))]
-        [Output("saturatedVapourPressure", "Saturated Vapour Pressure.", typeof(Pressure))]
+        [Description("Calculates saturated vapour pressure of water from temperature.")]
+        [Input("temperature", "Water temperature.", typeof(Temperature))]
+        [Output("saturatedVapourPressure", "Saturated vapour pressure.", typeof(Pressure))]
         public static double SaturatedVapourPressureWater(double temperature)
         {
             double pressureBars;

--- a/Psychrometrics_Engine/Compute/SpecificHeatCapacityWater.cs
+++ b/Psychrometrics_Engine/Compute/SpecificHeatCapacityWater.cs
@@ -35,9 +35,9 @@ namespace BH.Engine.Psychrometrics
 {
     public static partial class Compute
     {
-        [Description("Calculates Water SpecificHeatCapacity from water temperature.")]
-        [Input("temperature", "Water Temperature.", typeof(Temperature))]
-        [Output("specificHeatCapacity", "Specific Heat Capacity (kJ/kgK).")]
+        [Description("Calculates specific heat capacity of water from temperature.")]
+        [Input("temperature", "Water temperature.", typeof(Temperature))]
+        [Output("specificHeatCapacity", "Specific heat capacity (kJ/kgK).")]
         public static double SpecificHeatCapacityWater(double temperature)
         {
             // add temperature conversion here

--- a/Psychrometrics_Engine/Compute/SpecificVolumeHumidityRatio.cs
+++ b/Psychrometrics_Engine/Compute/SpecificVolumeHumidityRatio.cs
@@ -31,15 +31,15 @@ namespace BH.Engine.Psychrometrics
     {
         [Description("Calculates specific volume from dry-bulb temperature and humidity ratio.")]
         [Input("dryBulbTemperature", "Dry-bulb temperature.", typeof(Temperature))]
-        [Input("humidityRatio", "humidity ratio (kg_water/kg_dryair)")]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("specificVolume", "specificVolume(m3/kg)")]
+        [Input("humidityRatio", "Humidity ratio (kg_water/kg_dryair).", typeof(Ratio))]
+        [Input("pressure", "Pressure.", typeof(Pressure))]
+        [Output("specificVolume", "Specific volume.", typeof(VolumePerQuantity))]
         public static double SpecificVolumeHumidityRatio(double dryBulbTemperature, double humidityRatio, double pressure)
         {
             if (dryBulbTemperature < 100)
             {
                 // This warning is added because this method used to take dryBulbTemperature in C.
-                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celcius/Fahrenheit instead of Kelvin. Check your inputs.");
+                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celsius/Fahrenheit instead of Kelvin. Check your inputs.");
             }
             PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
             return psy.GetMoistAirVolume(dryBulbTemperature.ToDegreeCelsius(), humidityRatio, pressure);

--- a/Psychrometrics_Engine/Compute/SpecificVolumeRelativeHumidity.cs
+++ b/Psychrometrics_Engine/Compute/SpecificVolumeRelativeHumidity.cs
@@ -31,15 +31,15 @@ namespace BH.Engine.Psychrometrics
     {
         [Description("Calculates specific volume from dry-bulb temperature and relative humidity.")]
         [Input("dryBulbTemperature", "Dry-bulb temperature.", typeof(Temperature))]
-        [Input("relativeHumidity", "relative humidity (%)")]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("specificVolume", "specific volume(m3/kg)")]
+        [Input("relativeHumidity", "Relative humidity (%).")]
+        [Input("pressure", "Pressure.", typeof(Pressure))]
+        [Output("specificVolume", "Specific volume.", typeof(VolumePerQuantity))]
         public static double SpecificVolumeRelativeHumidity(double dryBulbTemperature, double relativeHumidity, double pressure)
         {
             if (dryBulbTemperature < 100)
             {
                 // This warning is added because this method used to take dryBulbTemperature in C.
-                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celcius/Fahrenheit instead of Kelvin. Check your inputs.");
+                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celsius/Fahrenheit instead of Kelvin. Check your inputs.");
             }
             relativeHumidity = relativeHumidity / 100;
             PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);

--- a/Psychrometrics_Engine/Compute/SpecificVolumeWetBulbTemperature.cs
+++ b/Psychrometrics_Engine/Compute/SpecificVolumeWetBulbTemperature.cs
@@ -32,14 +32,14 @@ namespace BH.Engine.Psychrometrics
         [Description("Calculates specific volume from dry-bulb temperature and wet-bulb temperature.")]
         [Input("dryBulbTemperature", "Dry-bulb temperature.", typeof(Temperature))]
         [Input("wetBulbTemperature", "Wet-bulb temperature.", typeof(Temperature))]
-        [Input("pressure", "pressure (Pa)")]
-        [Output("specificVolume", "specific volume(m3/kg)")]
+        [Input("pressure", "Pressure.", typeof(Pressure))]
+        [Output("specificVolume", "Specific volume.", typeof(VolumePerQuantity))]
         public static double SpecificVolumeWetBulbTemperature(double dryBulbTemperature, double wetBulbTemperature, double pressure)
         {
             if (dryBulbTemperature < 100 || wetBulbTemperature < 100)
             {
                 // This warning is added because this method used to take temperatures in C.
-                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celcius/Fahrenheit instead of Kelvin. Check your inputs.");
+                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celsius/Fahrenheit instead of Kelvin. Check your inputs.");
             }
             PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
             double humidityRatio = psy.GetHumRatioFromTWetBulb(dryBulbTemperature.ToDegreeCelsius(), wetBulbTemperature.ToDegreeCelsius(), pressure);

--- a/Psychrometrics_Engine/Compute/TemperatureAtAltitude.cs
+++ b/Psychrometrics_Engine/Compute/TemperatureAtAltitude.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Psychrometrics
     {
         [Description("Calculates air temperature as a function of altitude above sea level.")]
         [Input("altitude", "Altitude above sea level.", typeof(Length))]
-        [Output("air temperature", "Air Temperature.", typeof(Temperature))]
+        [Output("air temperature", "Air temperature.", typeof(Temperature))]
         public static double TemperatureAtAltitude(double altitude)
         {
             PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);

--- a/Psychrometrics_Engine/Compute/WetBulbHumidityRatio.cs
+++ b/Psychrometrics_Engine/Compute/WetBulbHumidityRatio.cs
@@ -31,15 +31,15 @@ namespace BH.Engine.Psychrometrics
     {
         [Description("Calculates wet-bulb temperature from dry-bulb temperature and humidity ratio.")]
         [Input("dryBulbTemperature", "Dry-bulb temperature.", typeof(Temperature))]
-        [Input("humidityRatio", "humidity ratio (kg_water/kg_dryair)")]
-        [Input("pressure", "pressure (Pa)")]
+        [Input("humidityRatio", "Humidity ratio (kg_water/kg_dryair).", typeof(Ratio))]
+        [Input("pressure", "Pressure.", typeof(Pressure))]
         [Output("wetBulbTemperature", "Wet-bulb temperature.", typeof(Temperature))]
         public static double WetBulbHumidityRatio(double dryBulbTemperature, double humidityRatio, double pressure)
         {
             if (dryBulbTemperature < 100)
             {
                 // This warning is added because this method used to take dryBulbTemperature in C.
-                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celcius/Fahrenheit instead of Kelvin. Check your inputs.");
+                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celsius/Fahrenheit instead of Kelvin. Check your inputs.");
             }
             PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
             return psy.GetTWetBulbFromHumRatio(dryBulbTemperature.ToDegreeCelsius(), humidityRatio, pressure).FromDegreeCelsius();

--- a/Psychrometrics_Engine/Compute/WetBulbTemperatureRelativeHumidity.cs
+++ b/Psychrometrics_Engine/Compute/WetBulbTemperatureRelativeHumidity.cs
@@ -31,17 +31,17 @@ namespace BH.Engine.Psychrometrics
     {
         [Description("Calculates wet-bulb temperature from dry-bulb temperature and relative humidity.")]
         [Input("dryBulbTemperature", "Dry-bulb temperature.", typeof(Temperature))]
-        [Input("relativeHumidity", "relative humidity (%)")]
-        [Input("pressure", "pressure (Pa)")]
+        [Input("relativeHumidity", "Relative humidity (%).")]
+        [Input("pressure", "Pressure.", typeof(Pressure))]
         [Output("wetBulbTemperature", "Wet-bulb temperature.", typeof(Temperature))]
         public static double WetBulbTemperatureRelativeHumidity(double dryBulbTemperature, double relativeHumidity, double pressure)
         {
             if (dryBulbTemperature < 100)
             {
                 // This warning is added because this method used to take dryBulbTemperature in C.
-                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celcius/Fahrenheit instead of Kelvin. Check your inputs.");
+                Base.Compute.RecordWarning("It looks like you have entered a temperature in Celsius/Fahrenheit instead of Kelvin. Check your inputs.");
             }
-            relativeHumidity = relativeHumidity / 100;
+            relativeHumidity /= 100;
             PsychroLib.Psychrometrics psy = new PsychroLib.Psychrometrics(PsychroLib.UnitSystem.SI);
             return psy.GetTWetBulbFromRelHum(dryBulbTemperature.ToDegreeCelsius(), relativeHumidity, pressure).FromDegreeCelsius();
         }


### PR DESCRIPTION


   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #101 

<!-- Add short description of what has been fixed -->


### Test files
Run unit tests


### Changelog
 - Now compliant with case and punctuation rules in attributes
 - The full toolkit now references Quantities oM in attributes
 - Spelling fix of Celcius to Celsius


### Additional comments
<!-- As required -->